### PR TITLE
Account for error objects and not just strings

### DIFF
--- a/src/utils/prettifyAxiosError.ts
+++ b/src/utils/prettifyAxiosError.ts
@@ -1,10 +1,12 @@
 export default function prettifyAxiosError(e: any) {
   const responseData = e?.response?.data;
   const errMsg = e?.message;
-  if (responseData && errMsg) {
-    return `${errMsg}: ${responseData}`;
-  } else if (responseData) {
-    return responseData;
+  const errDetails = responseData?.message || responseData;
+
+  if (errDetails && errMsg) {
+    return `${errMsg}: ${errDetails}`;
+  } else if (errDetails) {
+    return errDetails;
   } else if (errMsg) {
     return errMsg;
   } else {


### PR DESCRIPTION
**Before:**
<img width="483" alt="Screenshot 2025-04-23 at 9 04 28 AM" src="https://github.com/user-attachments/assets/2cfb6d98-b96a-453f-ad44-32b9fbd66b4e" />

**After:**
<img width="703" alt="Screenshot 2025-04-23 at 9 05 38 AM" src="https://github.com/user-attachments/assets/355b4ac8-cb71-44a0-b9ed-8b2a3a786470" />
