### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,17 @@
 name: Test
 on:
   pull_request:
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
@@ -14,8 +20,12 @@ jobs:
       - run: npm run build
   format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary

Fixed the following zizmor security findings in GitHub Actions workflow files:

- **artipacked** (`.github/workflows/build.yaml:12`) — added `persist-credentials: false` to `actions/checkout` step
- **artipacked** (`.github/workflows/test.yaml:8`) — added `persist-credentials: false` to `actions/checkout` step in `build` job
- **artipacked** (`.github/workflows/test.yaml:18`) — added `persist-credentials: false` to `actions/checkout` step in `format` job
- **excessive-permissions** (`.github/workflows/test.yaml:1`) — added top-level `permissions: contents: read` block
- **excessive-permissions** (`.github/workflows/test.yaml:5`) — added `permissions: contents: read` to `build` job
- **excessive-permissions** (`.github/workflows/test.yaml:15`) — added `permissions: contents: read` to `format` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)